### PR TITLE
Form connection according to spec

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,100 +1,92 @@
-"use strict";
-
-import {EventEmitter2 as EventEmitter} from 'eventemitter2';
+import { EventEmitter2 as EventEmitter } from 'eventemitter2';
 import * as jmp from 'jmp';
 import * as uuid from 'uuid';
 
+function formConnectionString(config, channel) {
+  const portDelimiter = config.transport === 'tcp' ? ':' : '-';
+  const port = config[channel + '_port'];
+  if (! port) {
+    throw new Error(`Port not found for channel "${channel}"`);
+  }
+  return `${config.transport}://${config.ip}${portDelimiter}${port}`;
+}
+
 export default class JupyterTransportWrapper extends EventEmitter {
     constructor(config, kernelProcess) {
-        super({wildcard: true});
+      super({ wildcard: true });
 
-        this.kernelProcess = kernelProcess;
-        this.shellSocket = new jmp.Socket(
-            'dealer',
-            config.signature_scheme,
-            config.key);
+      const scheme = config.signature_scheme.slice('hmac-'.length);
 
-        this.controlSocket = new jmp.Socket(
-            'dealer',
-            config.signature_scheme,
-            config.key);
+      this.kernelProcess = kernelProcess;
+      this.shellSocket = new jmp.Socket('dealer', scheme, config.key);
+      this.controlSocket = new jmp.Socket('dealer', scheme, config.key);
+      this.ioSocket = new jmp.Socket('sub', config.signature_scheme, config.key);
 
-        this.ioSocket = new jmp.Socket(
-            'sub',
-            config.signature_scheme,
-            config.key);
+      this.shellSocket.identity = 'dealer' + uuid.v4();
+      this.controlSocket.identity = 'control' + uuid.v4();
+      this.ioSocket.identity = 'sub' + uuid.v4();
 
-        this.shellSocket.identity = 'dealer' + uuid.v4();
-        this.controlSocket.identity = 'control' + uuid.v4();
-        this.ioSocket.identity = 'sub' + uuid.v4();
+      this.shellSocket.connect(formConnectionString(config, 'shell'));
+      this.controlSocket.connect(formConnectionString(config, 'control'));
+      this.ioSocket.connect(formConnectionString(config, 'iopub'));
 
-        this.shellSocket.connect(
-        config.address + ':' + config.shell_port);
-        this.controlSocket.connect(
-        config.address + ':' + config.control_port);
-        this.ioSocket.connect(
-        config.address + ':' + config.iopub_port);
+      this.ioSocket.subscribe('');
 
-        this.ioSocket.subscribe('');
-
-        this.shellSocket.on('message', this._onShellMessage.bind(this));
-        this.ioSocket.on('message', this._onIOMessage.bind(this));
+      this.shellSocket.on('message', this._onShellMessage.bind(this));
+      this.ioSocket.on('message', this._onIOMessage.bind(this));
     }
 
     _onShellMessage = (message) => {
-        message.channel = 'shell';
-        this._onMessage('shell', message);
+      message.channel = 'shell';
+      this._onMessage('shell', message);
     }
 
     _onIOMessage = (message) => {
-        message.channel = 'iopub';
-        this._onMessage('iopub', message);
+      message.channel = 'iopub';
+      this._onMessage('iopub', message);
     }
 
     _onMessage = (channel, message) => {
-        let eventName = channel;
-        if (message.parent_header !== undefined
-            && message.parent_header !== null
-            && message.parent_header.msg_id !== undefined
-            && message.parent_header.msg_id !== null) {
-            eventName = eventName + '.' + message.parent_header.msg_id;
-        }
-        this.emit(eventName, message);
+      console.log(channel);
+      console.log(message);
+      let eventName = channel;
+      if (message.parent_header && message.parent_header.msg_id) {
+        eventName = eventName + '.' + message.parent_header.msg_id;
+      }
+      this.emit(eventName, message);
     }
 
     send(channel, messageObject) {
-        let message = new jmp.Message(messageObject);
-        switch(channel) {
-            case 'iopub':
-                this.ioSocket.send(message);
-                break;
-            case 'shell':
-                this.shellSocket.send(message);
-                break;
-            case 'control':
-                this.controlSocket.send(message);
-                break;
-            default:
-                throw `'${channel}' is not a valid channel`;
-        }
+      const message = new jmp.Message(messageObject);
+      switch(channel) {
+      case 'iopub':
+        this.ioSocket.send(message);
+        break;
+      case 'shell':
+        this.shellSocket.send(message);
+        break;
+      case 'control':
+        this.controlSocket.send(message);
+        break;
+      default:
+        throw new Error(`'${channel}' is not a valid channel`);
+      }
     }
 
     interrupt() {
-        if (this.kernelProcess !== null
-            && this.kernelProcess !== undefined) {
-            this.kernelProcess.kill('SIGINT');
-        }
+      if (this.kernelProcess) {
+        this.kernelProcess.kill('SIGINT');
+      }
     }
 
     close() {
-        this.removeAllListeners();
-        this.shellSocket.close();
-        this.ioSocket.close();
-        this.controlSocket.close();
+      this.removeAllListeners();
+      this.shellSocket.close();
+      this.ioSocket.close();
+      this.controlSocket.close();
 
-        if (this.kernelProcess !== null
-            && this.kernelProcess !== undefined) {
-            this.kernelProcess.kill('SIGKILL');
-        }
+      if (this.kernelProcess) {
+        this.kernelProcess.kill('SIGKILL');
+      }
     }
 }


### PR DESCRIPTION
Tried this out today, ran into trouble receiving messages though I could work with the raw `jmp` setup just fine. Rather than debug EventEmitter2, I think I'll carry on with exploring how I'd do the same with RxJS's `Observable`s, the multi-valued yin to the `promise`s single-valued yang.

![image](https://cloud.githubusercontent.com/assets/836375/12254794/4bc5d0d0-b8b2-11e5-8a86-ac1a89b343b7.png)

Both EventEmitter and Observables are implementations of the Observer pattern. The difference with Rx is that they let you transform and combine event streams in a functional programming way. That being said, I'm planning on adapting this code (and the intention) into 3 packages:

* `enchannel`
* `enchannel-zmq-backend`
* `enchannel-nb-websocket-backend` (because this would probably be connected to a current day notebook server or kernel gateway)

Names are totally a work in progress. They could have jupyter in them too for all I care.